### PR TITLE
Fixed e2e workflow issue

### DIFF
--- a/internal/utils.go
+++ b/internal/utils.go
@@ -46,6 +46,9 @@ func FormatCacheSize(size_in_bytes float64) string {
 func PrettyPrintCacheList(caches []types.ActionsCache) {
 	terminal := ghTerm.FromEnv()
 	w, _, _ := terminal.Size()
+	if w == 0 {
+		w = 300
+	}
 	tp := ghTableprinter.New(os.Stdout, true, w)
 
 	for _, cache := range caches {

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -46,6 +46,8 @@ func FormatCacheSize(size_in_bytes float64) string {
 func PrettyPrintCacheList(caches []types.ActionsCache) {
 	terminal := ghTerm.FromEnv()
 	w, _, _ := terminal.Size()
+	// Checking w as its 0 if running non-interactively. 
+	// We need to set a default value in order to run e2e test workflow   
 	if w == 0 {
 		w = 300
 	}


### PR DESCRIPTION
### What are you trying to accomplish?

Fixed the e2e test [workflow run](https://github.com/actions/gh-actions-cache/actions/runs/2838526526) 

### What approach did you choose and why?

The failure was due to the terminal width being 0 in the workflow run. Now we are setting a default value of 300 if the width is 0. 

### Anything you want to highlight for special attention from reviewers?

No