### PR TITLE
Fixed e2e workflow issue

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const VERSION = "1.0.0"
+const VERSION = "1.0.1"
 
 var rootCmd = &cobra.Command{
 	Use:   "gh-actions-cache",

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -46,7 +46,7 @@ func FormatCacheSize(size_in_bytes float64) string {
 func PrettyPrintCacheList(caches []types.ActionsCache) {
 	terminal := ghTerm.FromEnv()
 	w, _, _ := terminal.Size()
-	tp := ghTableprinter.New(os.Stdout, true, w)
+	tp := ghTableprinter.New(terminal.Out(), terminal.IsTerminalOutput(), w)
 
 	for _, cache := range caches {
 		tp.AddField(cache.Key)

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -3,7 +3,6 @@ package internal
 import (
 	"errors"
 	"fmt"
-	"os"
 	"unicode/utf8"
 
 	"github.com/TwiN/go-color"


### PR DESCRIPTION
### What are you trying to accomplish?

Fixed the e2e test [workflow run](https://github.com/actions/gh-actions-cache/actions/runs/2838526526) 

### What approach did you choose and why?

Instead of hardcoding the output to be stdout we are now leaving that to go-gh. 

https://github.com/cli/go-gh/blob/198075af3bddf47429264b491742d5013287061a/pkg/tableprinter/table.go#L40

>New initializes a table printer with terminal mode and terminal width. When terminal mode is enabled, the
output will be human-readable, column-formatted to fit available width, and rendered with color support.
 In non-terminal mode, the output is tab-separated and all truncation of values is disabled.

### Anything you want to highlight for special attention from reviewers?

<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes. Highlight anything on which you would like a second (or third) opinion. -->