### PR TITLE
Fixed -L shorthand bug for list command (#33)

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -69,7 +69,7 @@ func NewCmdList() *cobra.Command {
 
 	listCmd.Flags().StringVarP(&f.Repo, "repo", "R", "", "Select another repository for finding actions cache.")
 	listCmd.Flags().StringVarP(&f.Branch, "branch", "B", "", "Filter by branch")
-	listCmd.Flags().IntVarP(&f.Limit, "limit", "", 30, "Number of items to fetch between 1 and 100")
+	listCmd.Flags().IntVarP(&f.Limit, "limit", "L", 30, "Number of items to fetch between 1 and 100")
 	listCmd.Flags().StringVarP(&f.Key, "key", "", "", "Filter by key")
 	listCmd.Flags().StringVarP(&f.Order, "order", "", "", "Order of caches returned (asc/desc)")
 	listCmd.Flags().StringVarP(&f.Sort, "sort", "", "", "Sort fetched caches (last-used/size/created-at)")

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -62,7 +62,7 @@ func TestListWithIncorrectLimit(t *testing.T) {
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
-func TestListWithIncorrectLimit2(t *testing.T) {
+func TestListLimitShorthandUsingIncorrectLimit(t *testing.T) {
 	t.Cleanup(gock.Off)
 
 	cmd := NewCmdList()

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -62,6 +62,18 @@ func TestListWithIncorrectLimit(t *testing.T) {
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
+func TestListWithIncorrectLimit2(t *testing.T) {
+	t.Cleanup(gock.Off)
+
+	cmd := NewCmdList()
+	cmd.SetArgs([]string{"-L", "102", "--repo", "testOrg/testRepo"})
+	err := cmd.Execute()
+
+	assert.NotNil(t, err)
+	assert.Equal(t, err, fmt.Errorf("102 is not a valid integer value for limit flag. Allowed values: 1-100"))
+	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
+}
+
 func TestListWithIncorrectOrder(t *testing.T) {
 	t.Cleanup(gock.Off)
 


### PR DESCRIPTION
### What are you trying to accomplish?

Fixed -L shorthand bug for list command. (#33)

### What approach did you choose and why?

Added -L shorthand to use correctly with list command and added test for it. 

### Anything you want to highlight for special attention from reviewers?

Added test with using -L shorthand.