### PR TITLE
Update canary and e2e workflow to use checkout@v3 - node16 version

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -35,7 +35,7 @@ jobs:
       CacheKey: ${{ matrix.os }}-runner-${{ github.run_number }}-${{ github.run_attempt }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install extension
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -34,7 +34,7 @@ jobs:
       CacheKey: ${{ matrix.os }}-runner-${{ github.run_number }}-${{ github.run_attempt }}
     steps:
       - name: checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Restore Go modules cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
### What are you trying to accomplish?

The workflows use `actions/checkout@v2` version that uses the deprecated node12. The PR updates the workflows to use `actions/checkout@v3` that uses node 16. 

### What approach did you choose and why?

`actions/checkout@v3` is the recommended version that uses node 16.

### Anything you want to highlight for special attention from reviewers?

No