### PR TITLE
Better testify usage

### DIFF
--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -19,7 +19,7 @@ func TestDeleteWithIncorrectArguments(t *testing.T) {
 	cmd.SetArgs([]string{})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("accepts 1 arg(s), received 0"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -31,7 +31,7 @@ func TestDeleteWithIncorrectRepo(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo/123/123", "cacheName"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, err, fmt.Errorf("expected the \"[HOST/]OWNER/REPO\" format, got \"testOrg/testRepo/123/123\""))
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -52,7 +52,7 @@ func TestDeleteWithIncorrectRepoForDeleteCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo", "cacheName"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 	var customError types.HandledError
 	errors.As(err, &customError)
@@ -116,7 +116,7 @@ func TestDeleteFailureWhileTakingUserInput(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo", "2022-06-29T13:33:49"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -135,7 +135,7 @@ func TestDeleteWithUnauthorizedRequestForDeleteCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo", "cacheKey", "--confirm"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
@@ -160,7 +160,7 @@ func TestDeleteWithInternalServerErrorForDeleteCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo", "cacheKey", "--confirm"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -20,7 +20,7 @@ func TestDeleteWithIncorrectArguments(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, fmt.Errorf("accepts 1 arg(s), received 0"))
+	assert.Equal(t, fmt.Errorf("accepts 1 arg(s), received 0"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -56,7 +56,7 @@ func TestDeleteWithIncorrectRepoForDeleteCaches(t *testing.T) {
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 	var customError types.HandledError
 	errors.As(err, &customError)
-	assert.Equal(t, customError.Message, "The given repo does not exist.")
+	assert.Equal(t, "The given repo does not exist.", customError.Message)
 }
 
 func TestDeleteSuccessWithConfirmFlagProvided(t *testing.T) {
@@ -136,11 +136,11 @@ func TestDeleteWithUnauthorizedRequestForDeleteCaches(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, reflect.TypeOf(err), reflect.TypeOf(types.HandledError{}))
+	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
 	errors.As(err, &customError)
-	assert.Equal(t, customError.Message, "Must have admin rights to Repository.")
+	assert.Equal(t, "Must have admin rights to Repository.", customError.Message)
 
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -161,11 +161,11 @@ func TestDeleteWithInternalServerErrorForDeleteCaches(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, reflect.TypeOf(err), reflect.TypeOf(types.HandledError{}))
+	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
 	errors.As(err, &customError)
-	assert.Equal(t, customError.Message, "We could not process your request due to internal error.")
+	assert.Equal(t, "We could not process your request due to internal error.", customError.Message)
 
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }

--- a/cmd/delete_test.go
+++ b/cmd/delete_test.go
@@ -85,7 +85,7 @@ func TestDeleteSuccessWithConfirmFlagProvided(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo", "2022-06-29T13:33:49", "--confirm"})
 	err := cmd.Execute()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -21,7 +21,7 @@ func TestListWithIncorrectArguments(t *testing.T) {
 	cmd.SetArgs([]string{"keyValue"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("Invalid argument(s). Expected 0 received 1"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -33,7 +33,7 @@ func TestListWithIncorrectRepo(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo/123/123"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, err, fmt.Errorf("expected the \"[HOST/]OWNER/REPO\" format, got \"testOrg/testRepo/123/123\""))
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -45,7 +45,7 @@ func TestListWithNegativeLimit(t *testing.T) {
 	cmd.SetArgs([]string{"--limit", "-1", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("-1 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -57,7 +57,7 @@ func TestListWithIncorrectLimit(t *testing.T) {
 	cmd.SetArgs([]string{"--limit", "101", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("101 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -69,7 +69,7 @@ func TestListLimitShorthandUsingIncorrectLimit(t *testing.T) {
 	cmd.SetArgs([]string{"-L", "102", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("102 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -81,7 +81,7 @@ func TestListWithIncorrectOrder(t *testing.T) {
 	cmd.SetArgs([]string{"--order", "incorrectOrderValue", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("incorrectOrderValue is not a valid value for order flag. Allowed values: asc/desc"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -93,7 +93,7 @@ func TestListWithIncorrectSort(t *testing.T) {
 	cmd.SetArgs([]string{"--sort", "incorrectSortValue", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, fmt.Errorf("incorrectSortValue is not a valid value for sort flag. Allowed values: last-used/size/created-at"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -121,7 +121,7 @@ func TestListWithIncorrectRepoForListCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
@@ -154,7 +154,7 @@ func TestListWithUnauthorizedRequestForListCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
@@ -187,7 +187,7 @@ func TestListWithInternalServerErrorForListCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -22,7 +22,7 @@ func TestListWithIncorrectArguments(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, fmt.Errorf("Invalid argument(s). Expected 0 received 1"))
+	assert.Equal(t, fmt.Errorf("Invalid argument(s). Expected 0 received 1"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -46,7 +46,7 @@ func TestListWithNegativeLimit(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, fmt.Errorf("-1 is not a valid integer value for limit flag. Allowed values: 1-100"))
+	assert.Equal(t, fmt.Errorf("-1 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -58,7 +58,7 @@ func TestListWithIncorrectLimit(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, fmt.Errorf("101 is not a valid integer value for limit flag. Allowed values: 1-100"))
+	assert.Equal(t, fmt.Errorf("101 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -70,7 +70,7 @@ func TestListLimitShorthandUsingIncorrectLimit(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, fmt.Errorf("102 is not a valid integer value for limit flag. Allowed values: 1-100"))
+	assert.Equal(t, fmt.Errorf("102 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -82,7 +82,7 @@ func TestListWithIncorrectOrder(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, fmt.Errorf("incorrectOrderValue is not a valid value for order flag. Allowed values: asc/desc"))
+	assert.Equal(t, fmt.Errorf("incorrectOrderValue is not a valid value for order flag. Allowed values: asc/desc"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -94,7 +94,7 @@ func TestListWithIncorrectSort(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, err, fmt.Errorf("incorrectSortValue is not a valid value for sort flag. Allowed values: last-used/size/created-at"))
+	assert.Equal(t, fmt.Errorf("incorrectSortValue is not a valid value for sort flag. Allowed values: last-used/size/created-at"), err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -122,11 +122,11 @@ func TestListWithIncorrectRepoForListCaches(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, reflect.TypeOf(err), reflect.TypeOf(types.HandledError{}))
+	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
 	errors.As(err, &customError)
-	assert.Equal(t, customError.Message, "The given repo does not exist.")
+	assert.Equal(t, "The given repo does not exist.", customError.Message)
 
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -155,11 +155,11 @@ func TestListWithUnauthorizedRequestForListCaches(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, reflect.TypeOf(err), reflect.TypeOf(types.HandledError{}))
+	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
 	errors.As(err, &customError)
-	assert.Equal(t, customError.Message, "Must have admin rights to Repository.")
+	assert.Equal(t, "Must have admin rights to Repository.", customError.Message)
 
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -188,11 +188,11 @@ func TestListWithInternalServerErrorForListCaches(t *testing.T) {
 	err := cmd.Execute()
 
 	assert.NotNil(t, err)
-	assert.Equal(t, reflect.TypeOf(err), reflect.TypeOf(types.HandledError{}))
+	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
 
 	var customError types.HandledError
 	errors.As(err, &customError)
-	assert.Equal(t, customError.Message, "We could not process your request due to internal error.")
+	assert.Equal(t, "We could not process your request due to internal error.", customError.Message)
 
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,10 +1,6 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
-
-	"reflect"
 	"testing"
 
 	"github.com/actions/gh-actions-cache/internal"
@@ -21,8 +17,7 @@ func TestListWithIncorrectArguments(t *testing.T) {
 	cmd.SetArgs([]string{"keyValue"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Errorf("Invalid argument(s). Expected 0 received 1"), err)
+	assert.ErrorContains(t, err, "Invalid argument(s). Expected 0 received 1")
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -33,8 +28,7 @@ func TestListWithIncorrectRepo(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo/123/123"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, err, fmt.Errorf("expected the \"[HOST/]OWNER/REPO\" format, got \"testOrg/testRepo/123/123\""))
+	assert.ErrorContains(t, err, "expected the \"[HOST/]OWNER/REPO\" format, got \"testOrg/testRepo/123/123\"")
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -45,8 +39,7 @@ func TestListWithNegativeLimit(t *testing.T) {
 	cmd.SetArgs([]string{"--limit", "-1", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Errorf("-1 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
+	assert.ErrorContains(t, err, "-1 is not a valid integer value for limit flag. Allowed values: 1-100")
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -57,8 +50,7 @@ func TestListWithIncorrectLimit(t *testing.T) {
 	cmd.SetArgs([]string{"--limit", "101", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Errorf("101 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
+	assert.ErrorContains(t, err, "101 is not a valid integer value for limit flag. Allowed values: 1-100")
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -69,8 +61,7 @@ func TestListLimitShorthandUsingIncorrectLimit(t *testing.T) {
 	cmd.SetArgs([]string{"-L", "102", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Errorf("102 is not a valid integer value for limit flag. Allowed values: 1-100"), err)
+	assert.ErrorContains(t, err, "102 is not a valid integer value for limit flag. Allowed values: 1-100")
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -81,8 +72,7 @@ func TestListWithIncorrectOrder(t *testing.T) {
 	cmd.SetArgs([]string{"--order", "incorrectOrderValue", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Errorf("incorrectOrderValue is not a valid value for order flag. Allowed values: asc/desc"), err)
+	assert.ErrorContains(t, err, "incorrectOrderValue is not a valid value for order flag. Allowed values: asc/desc")
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -93,8 +83,7 @@ func TestListWithIncorrectSort(t *testing.T) {
 	cmd.SetArgs([]string{"--sort", "incorrectSortValue", "--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, fmt.Errorf("incorrectSortValue is not a valid value for sort flag. Allowed values: last-used/size/created-at"), err)
+	assert.ErrorContains(t, err, "incorrectSortValue is not a valid value for sort flag. Allowed values: last-used/size/created-at")
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -121,13 +110,10 @@ func TestListWithIncorrectRepoForListCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
-
 	var customError types.HandledError
-	errors.As(err, &customError)
-	assert.Equal(t, "The given repo does not exist.", customError.Message)
-
+	if assert.ErrorAs(t, err, &customError) {
+		assert.Equal(t, "The given repo does not exist.", customError.Message)
+	}
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -154,13 +140,10 @@ func TestListWithUnauthorizedRequestForListCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
-
 	var customError types.HandledError
-	errors.As(err, &customError)
-	assert.Equal(t, "Must have admin rights to Repository.", customError.Message)
-
+	if assert.ErrorAs(t, err, &customError) {
+		assert.Equal(t, "Must have admin rights to Repository.", customError.Message)
+	}
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -187,13 +170,10 @@ func TestListWithInternalServerErrorForListCaches(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Error(t, err)
-	assert.Equal(t, reflect.TypeOf(types.HandledError{}), reflect.TypeOf(err))
-
 	var customError types.HandledError
-	errors.As(err, &customError)
-	assert.Equal(t, "We could not process your request due to internal error.", customError.Message)
-
+	if assert.ErrorAs(t, err, &customError) {
+		assert.Equal(t, "We could not process your request due to internal error.", customError.Message)
+	}
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -229,6 +229,6 @@ func TestListSuccess(t *testing.T) {
 	cmd.SetArgs([]string{"--repo", "testOrg/testRepo"})
 	err := cmd.Execute()
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -20,28 +20,29 @@ func TestGetRepo_CorrectRepoString(t *testing.T) {
 	repo, err := GetRepo(r)
 
 	assert.NoError(t, err)
-	assert.NotNil(t, repo)
-	assert.Equal(t, "github.com", repo.Host())
-	assert.Equal(t, "testOrg", repo.Owner())
-	assert.Equal(t, "testRepo", repo.Name())
+	if assert.NotNil(t, repo) {
+		assert.Equal(t, "github.com", repo.Host())
+		assert.Equal(t, "testOrg", repo.Owner())
+		assert.Equal(t, "testRepo", repo.Name())
+	}
 }
 
 func TestGetRepo_CorrectRepoStringWithCustomHost(t *testing.T) {
 	r := "api.testEnterprise.com/testOrg/testRepo"
 	repo, err := GetRepo(r)
 
-	assert.NotNil(t, repo)
 	assert.NoError(t, err)
-	assert.Equal(t, "api.testEnterprise.com", repo.Host())
-	assert.Equal(t, "testOrg", repo.Owner())
-	assert.Equal(t, "testRepo", repo.Name())
+	if assert.NotNil(t, repo) {
+		assert.Equal(t, "api.testEnterprise.com", repo.Host())
+		assert.Equal(t, "testOrg", repo.Owner())
+		assert.Equal(t, "testRepo", repo.Name())
+	}
 }
 
 func TestFormatCacheSize_MB(t *testing.T) {
 	cacheSizeInBytes := 1024 * 1024 * 1.5
 	cacheSizeDetailString := FormatCacheSize(cacheSizeInBytes)
 
-	assert.NotNil(t, cacheSizeDetailString)
 	assert.Equal(t, "1.50 MB", cacheSizeDetailString)
 }
 
@@ -49,6 +50,5 @@ func TestFormatCacheSize_GB(t *testing.T) {
 	cacheSizeInBytes := 1024 * 1024 * 1024 * 1.5
 	cacheSizeDetailString := FormatCacheSize(cacheSizeInBytes)
 
-	assert.NotNil(t, cacheSizeDetailString)
 	assert.Equal(t, "1.50 GB", cacheSizeDetailString)
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -20,11 +20,11 @@ func TestGetRepo_CorrectRepoString(t *testing.T) {
 	r := "testOrg/testRepo"
 	repo, err := GetRepo(r)
 
-	assert.NotNil(t, repo)
 	assert.NoError(t, err)
-	assert.Equal(t, repo.Host(), "github.com")
-	assert.Equal(t, repo.Owner(), "testOrg")
-	assert.Equal(t, repo.Name(), "testRepo")
+	assert.NotNil(t, repo)
+	assert.Equal(t, "github.com", repo.Host())
+	assert.Equal(t, "testOrg", repo.Owner())
+	assert.Equal(t, "testRepo", repo.Name())
 }
 
 func TestGetRepo_CorrectRepoStringWithCustomHost(t *testing.T) {
@@ -33,9 +33,9 @@ func TestGetRepo_CorrectRepoStringWithCustomHost(t *testing.T) {
 
 	assert.NotNil(t, repo)
 	assert.NoError(t, err)
-	assert.Equal(t, repo.Host(), "api.testEnterprise.com")
-	assert.Equal(t, repo.Owner(), "testOrg")
-	assert.Equal(t, repo.Name(), "testRepo")
+	assert.Equal(t, "api.testEnterprise.com", repo.Host())
+	assert.Equal(t, "testOrg", repo.Owner())
+	assert.Equal(t, "testRepo", repo.Name())
 }
 
 func TestFormatCacheSize_MB(t *testing.T) {
@@ -43,7 +43,7 @@ func TestFormatCacheSize_MB(t *testing.T) {
 	cacheSizeDetailString := FormatCacheSize(cacheSizeInBytes)
 
 	assert.NotNil(t, cacheSizeDetailString)
-	assert.Equal(t, cacheSizeDetailString, "1.50 MB")
+	assert.Equal(t, "1.50 MB", cacheSizeDetailString)
 }
 
 func TestFormatCacheSize_GB(t *testing.T) {
@@ -51,5 +51,5 @@ func TestFormatCacheSize_GB(t *testing.T) {
 	cacheSizeDetailString := FormatCacheSize(cacheSizeInBytes)
 
 	assert.NotNil(t, cacheSizeDetailString)
-	assert.Equal(t, cacheSizeDetailString, "1.50 GB")
+	assert.Equal(t, "1.50 GB", cacheSizeDetailString)
 }

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -21,7 +21,7 @@ func TestGetRepo_CorrectRepoString(t *testing.T) {
 	repo, err := GetRepo(r)
 
 	assert.NotNil(t, repo)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, repo.Host(), "github.com")
 	assert.Equal(t, repo.Owner(), "testOrg")
 	assert.Equal(t, repo.Name(), "testRepo")
@@ -32,7 +32,7 @@ func TestGetRepo_CorrectRepoStringWithCustomHost(t *testing.T) {
 	repo, err := GetRepo(r)
 
 	assert.NotNil(t, repo)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, repo.Host(), "api.testEnterprise.com")
 	assert.Equal(t, repo.Owner(), "testOrg")
 	assert.Equal(t, repo.Name(), "testRepo")

--- a/internal/utils_test.go
+++ b/internal/utils_test.go
@@ -11,9 +11,8 @@ func TestGetRepo_IncorrectRepoString(t *testing.T) {
 	r := "testOrg/testRepo/123/123"
 	repo, err := GetRepo(r)
 
-	assert.Error(t, err)
+	assert.ErrorContains(t, err, fmt.Sprintf("expected the \"[HOST/]OWNER/REPO\" format, got \"%s\"", r))
 	assert.Nil(t, repo)
-	assert.Equal(t, err.Error(), fmt.Sprintf("expected the \"[HOST/]OWNER/REPO\" format, got \"%s\"", r))
 }
 
 func TestGetRepo_CorrectRepoString(t *testing.T) {

--- a/service/actions_cache_test.go
+++ b/service/actions_cache_test.go
@@ -58,7 +58,7 @@ func TestGetCacheUsage_IncorrectRepo(t *testing.T) {
 	var httpError api.HTTPError
 	errors.As(err, &httpError)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, 404, httpError.StatusCode)
 	assert.Equal(t, "Not Found", httpError.Message)
 	assert.Equal(t, float64(-1), totalCacheSize)
@@ -128,7 +128,7 @@ func TestListCaches_Failure(t *testing.T) {
 	var httpError api.HTTPError
 	errors.As(err, &httpError)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, 404, httpError.StatusCode)
 	assert.Equal(t, "Not Found", httpError.Message)
 	assert.Equal(t, types.ListApiResponse{}, listCacheResponse)
@@ -193,7 +193,7 @@ func TestDeleteCaches_Failure(t *testing.T) {
 	assert.NoError(t, err)
 	deletedCache, err := artifactCache.DeleteCaches(queryParams)
 
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, 0, deletedCache)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }

--- a/service/actions_cache_test.go
+++ b/service/actions_cache_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/actions/gh-actions-cache/types"
 	"github.com/cli/go-gh/pkg/api"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -26,14 +27,15 @@ func TestGetCacheUsage_CorrectRepo(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, artifactCache)
 	totalCacheSize, err := artifactCache.GetCacheUsage()
 
-	assert.Equal(t, float64(291205), totalCacheSize)
 	assert.NoError(t, err)
+	assert.Equal(t, float64(291205), totalCacheSize)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -49,10 +51,11 @@ func TestGetCacheUsage_IncorrectRepo(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/wrongRepo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, artifactCache)
 	totalCacheSize, err := artifactCache.GetCacheUsage()
 	var httpError api.HTTPError
 	if assert.ErrorAs(t, err, &httpError) {
@@ -84,21 +87,23 @@ func TestListCaches_Success(t *testing.T) {
 			}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	f := types.ListOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}, Limit: 30}
 	queryParams := url.Values{}
 	f.GenerateQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, artifactCache)
 	listCacheResponse, err := artifactCache.ListCaches(queryParams)
 
 	assert.NoError(t, err)
-	assert.NotNil(t, listCacheResponse)
-	assert.Equal(t, 1, listCacheResponse.TotalCount)
-	assert.Equal(t, 1, len(listCacheResponse.ActionsCaches))
-	assert.Equal(t, 29, listCacheResponse.ActionsCaches[0].Id)
+	if assert.NotNil(t, listCacheResponse) {
+		assert.Equal(t, 1, listCacheResponse.TotalCount)
+		assert.Equal(t, 1, len(listCacheResponse.ActionsCaches))
+		assert.Equal(t, 29, listCacheResponse.ActionsCaches[0].Id)
+	}
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -114,14 +119,15 @@ func TestListCaches_Failure(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	f := types.ListOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}, Limit: 30}
 	queryParams := url.Values{}
 	f.GenerateQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, artifactCache)
 	listCacheResponse, err := artifactCache.ListCaches(queryParams)
 	var httpError api.HTTPError
 	if assert.ErrorAs(t, err, &httpError) {
@@ -153,14 +159,15 @@ func TestDeleteCaches_Success(t *testing.T) {
 			}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	f := types.DeleteOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}}
 	queryParams := url.Values{}
 	f.GenerateBaseQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "delete", VERSION)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, artifactCache)
 	deletedCache, err := artifactCache.DeleteCaches(queryParams)
 
 	assert.NoError(t, err)
@@ -180,14 +187,15 @@ func TestDeleteCaches_Failure(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	f := types.DeleteOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}}
 	queryParams := url.Values{}
 	f.GenerateBaseQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "delete", VERSION)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, artifactCache)
 	deletedCache, err := artifactCache.DeleteCaches(queryParams)
 
 	assert.Error(t, err)

--- a/service/actions_cache_test.go
+++ b/service/actions_cache_test.go
@@ -27,14 +27,14 @@ func TestGetCacheUsage_CorrectRepo(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	totalCacheSize, err := artifactCache.GetCacheUsage()
 
 	assert.Equal(t, totalCacheSize, float64(291205))
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -50,10 +50,10 @@ func TestGetCacheUsage_IncorrectRepo(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/wrongRepo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	totalCacheSize, err := artifactCache.GetCacheUsage()
 	var httpError api.HTTPError
 	errors.As(err, &httpError)
@@ -86,17 +86,17 @@ func TestListCaches_Success(t *testing.T) {
 			}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	f := types.ListOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}, Limit: 30}
 	queryParams := url.Values{}
 	f.GenerateQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	listCacheResponse, err := artifactCache.ListCaches(queryParams)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.NotNil(t, listCacheResponse)
 	assert.Equal(t, listCacheResponse.TotalCount, 1)
 	assert.Equal(t, len(listCacheResponse.ActionsCaches), 1)
@@ -116,14 +116,14 @@ func TestListCaches_Failure(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	f := types.ListOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}, Limit: 30}
 	queryParams := url.Values{}
 	f.GenerateQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "list", VERSION)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	listCacheResponse, err := artifactCache.ListCaches(queryParams)
 	var httpError api.HTTPError
 	errors.As(err, &httpError)
@@ -156,17 +156,17 @@ func TestDeleteCaches_Success(t *testing.T) {
 			}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	f := types.DeleteOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}}
 	queryParams := url.Values{}
 	f.GenerateBaseQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "delete", VERSION)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	deletedCache, err := artifactCache.DeleteCaches(queryParams)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, deletedCache, 1)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -183,14 +183,14 @@ func TestDeleteCaches_Failure(t *testing.T) {
 		}`)
 
 	repo, err := internal.GetRepo("testOrg/testRepo")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	f := types.DeleteOptions{BaseOptions: types.BaseOptions{Repo: "testOrg/testRepo"}}
 	queryParams := url.Values{}
 	f.GenerateBaseQueryParams(queryParams)
 
 	artifactCache, err := NewArtifactCache(repo, "delete", VERSION)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	deletedCache, err := artifactCache.DeleteCaches(queryParams)
 
 	assert.NotNil(t, err)

--- a/service/actions_cache_test.go
+++ b/service/actions_cache_test.go
@@ -33,7 +33,7 @@ func TestGetCacheUsage_CorrectRepo(t *testing.T) {
 	assert.NoError(t, err)
 	totalCacheSize, err := artifactCache.GetCacheUsage()
 
-	assert.Equal(t, totalCacheSize, float64(291205))
+	assert.Equal(t, float64(291205), totalCacheSize)
 	assert.NoError(t, err)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -59,9 +59,9 @@ func TestGetCacheUsage_IncorrectRepo(t *testing.T) {
 	errors.As(err, &httpError)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, httpError.StatusCode, 404)
-	assert.Equal(t, httpError.Message, "Not Found")
-	assert.Equal(t, totalCacheSize, float64(-1))
+	assert.Equal(t, 404, httpError.StatusCode)
+	assert.Equal(t, "Not Found", httpError.Message)
+	assert.Equal(t, float64(-1), totalCacheSize)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -98,9 +98,9 @@ func TestListCaches_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.NotNil(t, listCacheResponse)
-	assert.Equal(t, listCacheResponse.TotalCount, 1)
-	assert.Equal(t, len(listCacheResponse.ActionsCaches), 1)
-	assert.Equal(t, listCacheResponse.ActionsCaches[0].Id, 29)
+	assert.Equal(t, 1, listCacheResponse.TotalCount)
+	assert.Equal(t, 1, len(listCacheResponse.ActionsCaches))
+	assert.Equal(t, 29, listCacheResponse.ActionsCaches[0].Id)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -129,9 +129,9 @@ func TestListCaches_Failure(t *testing.T) {
 	errors.As(err, &httpError)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, httpError.StatusCode, 404)
-	assert.Equal(t, httpError.Message, "Not Found")
-	assert.Equal(t, listCacheResponse, types.ListApiResponse{})
+	assert.Equal(t, 404, httpError.StatusCode)
+	assert.Equal(t, "Not Found", httpError.Message)
+	assert.Equal(t, types.ListApiResponse{}, listCacheResponse)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -167,7 +167,7 @@ func TestDeleteCaches_Success(t *testing.T) {
 	deletedCache, err := artifactCache.DeleteCaches(queryParams)
 
 	assert.NoError(t, err)
-	assert.Equal(t, deletedCache, 1)
+	assert.Equal(t, 1, deletedCache)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
 
@@ -194,6 +194,6 @@ func TestDeleteCaches_Failure(t *testing.T) {
 	deletedCache, err := artifactCache.DeleteCaches(queryParams)
 
 	assert.NotNil(t, err)
-	assert.Equal(t, deletedCache, 0)
+	assert.Equal(t, 0, deletedCache)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }

--- a/service/actions_cache_test.go
+++ b/service/actions_cache_test.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"errors"
 	"net/url"
 	"testing"
 
@@ -56,11 +55,10 @@ func TestGetCacheUsage_IncorrectRepo(t *testing.T) {
 	assert.NoError(t, err)
 	totalCacheSize, err := artifactCache.GetCacheUsage()
 	var httpError api.HTTPError
-	errors.As(err, &httpError)
-
-	assert.Error(t, err)
-	assert.Equal(t, 404, httpError.StatusCode)
-	assert.Equal(t, "Not Found", httpError.Message)
+	if assert.ErrorAs(t, err, &httpError) {
+		assert.Equal(t, 404, httpError.StatusCode)
+		assert.Equal(t, "Not Found", httpError.Message)
+	}
 	assert.Equal(t, float64(-1), totalCacheSize)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }
@@ -126,11 +124,10 @@ func TestListCaches_Failure(t *testing.T) {
 	assert.NoError(t, err)
 	listCacheResponse, err := artifactCache.ListCaches(queryParams)
 	var httpError api.HTTPError
-	errors.As(err, &httpError)
-
-	assert.Error(t, err)
-	assert.Equal(t, 404, httpError.StatusCode)
-	assert.Equal(t, "Not Found", httpError.Message)
+	if assert.ErrorAs(t, err, &httpError) {
+		assert.Equal(t, 404, httpError.StatusCode)
+		assert.Equal(t, "Not Found", httpError.Message)
+	}
 	assert.Equal(t, types.ListApiResponse{}, listCacheResponse)
 	assert.True(t, gock.IsDone(), internal.PrintPendingMocks(gock.Pending()))
 }


### PR DESCRIPTION
### What are you trying to accomplish?

Better UX in case of test failures:

- Better assertion messages
- No unneeded panics

Moreover: Make code related to test assertions a bit more concise.

### What approach did you choose and why?

* Use `assert.NoError` instead of `assert.Nil`
  This gives nicer error messages.

* Swap arguments to `assert.Equal`
  The expectation comes first. Otherwise, error messages will be misleading.

* Use `assert.Error` instead of `assert.NotNil`
  This gives nicer error messages.

* Use `assert.ErrorAs` and `assert.ErrorContains`
  This simplifies the assertions and potentially gives better error messages.

* Use `require` instead of `assert` and use `assert.NotNil` as guard
  This is to prevent panics in tests, when things get accessed which shouldn't be `nil`.

### Anything you want to highlight for special attention from reviewers?

An example of a misleading assertion message (expected and actual are flipped):

```
=== RUN   TestDeleteWithIncorrectRepoForDeleteCaches
Error: authentication token not found for host github.com
	delete_test.go:56:
				Error Trace:    /build/source/cmd/delete_test.go:56
				Error:          Should be true
				Test:           TestDeleteWithIncorrectRepoForDeleteCaches
				Messages:       1 unmatched mocks: https://api.github.com/repos/testOrg/testRepo/actions/caches?key=cacheName
	delete_test.go:59:
				Error Trace:    /build/source/cmd/delete_test.go:59
				Error:          Not equal:
								expected: "authentication token not found for host github.com"
								actual  : "The given repo does not exist."

								Diff:
								--- Expected
								+++ Actual
								@@ -1 +1 @@
								-authentication token not found for host github.com
								+The given repo does not exist.
				Test:           TestDeleteWithIncorrectRepoForDeleteCaches
--- FAIL: TestDeleteWithIncorrectRepoForDeleteCaches (0.00s)
```