### PR TITLE
cli/gh-extension-precompile env:  CGO_ENABLED: 0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,7 @@ jobs:
           GH_TOKEN: dummy-token-to-facilitate-rest-client
 
       - uses: cli/gh-extension-precompile@v1
+        env:
+          CGO_ENABLED: 0
         with:
           go_version: "1.18"


### PR DESCRIPTION
set env: CGO_ENABLED: 0
for cli/gh-extension-precompile
should fix  https://github.com/actions/gh-actions-cache/issues/56

without it it fail with: version `GLIBC_2.32' not found on Debian bullseye  
$ gh actions-cache list
/home/user/.local/share/gh/extensions/gh-actions-cache/gh-actions-cache: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/user/.local/share/gh/extensions/gh-actions-cache/gh-actions-cache)
/home/user/.local/share/gh/extensions/gh-actions-cache/gh-actions-cache: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/user/.local/share/gh/extensions/gh-actions-cache/gh-actions-cache)
