### PR TITLE
Fix token

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -38,12 +38,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Install extension
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh extensions install actions/gh-actions-cache
       - name: List Command
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cache_found=$(gh actions-cache list --key $CacheKey --limit 100 --branch $GITHUB_REF --order desc --sort created-at | grep  $CacheKey)
           echo $cache_found
@@ -51,7 +51,7 @@ jobs:
       - name: Delete Command
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cache_delete=$(gh actions-cache delete $CacheKey --branch $GITHUB_REF --confirm | grep "Deleted 1 cache entry with key")
           echo $cache_delete


### PR DESCRIPTION
Closes https://github.com/github/actions-platform-delta/issues/646
Better to use an actions token than a specific user's PAT token which will change if the user changes employment

### What are you trying to accomplish?

@aparna-ravindra generated a PAT token to be used here but it may no longer be valid and it would be better to use a generic repo token which will always work as opposed to a PAT token which expires and depends on the user's membership of the org.

Context: https://github.slack.com/archives/C03BSM78LRX/p1683280039664249
