### PR TITLE
ci(e2e_test): Disable CGO_ENABLED to validate static build

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -43,7 +43,7 @@ jobs:
           restore-keys: |
             go-${{ runner.os }}-
       - name: Build the project
-        run: go build
+        run: CGO_ENABLED=0 go build
       - name: Install extension
         env:
           GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}


### PR DESCRIPTION
Related to #62

### What are you trying to accomplish?

This is a CI improvement related to #62 to ensure that `gh-actions-cache` static builds succeed in CI runs.

<!-- Provide a description of the changes, including any screenshots, videos, or graphs if applicable. Link to any related issues or projects here. -->

### What approach did you choose and why?

<!-- This section is a place for you to describe your thought process in making these changes. List any tradeoffs you made to take on or pay down tech debt. Identify any work you did to mitigate risk. Describe any alternative approaches you considered and why you discarded them. -->

Add the `CGO_ENABLED=0` env var setting inline.

### Anything you want to highlight for special attention from reviewers?

<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes. Highlight anything on which you would like a second (or third) opinion. -->