### PR TITLE
Fix e2e handling for PRs in forks

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -80,7 +80,7 @@ jobs:
           echo $cache_delete
           [[ -z "$cache_delete" ]] && exit 1 || echo "Cache Delete Successful"
       - name: Slack Notification on failure
-        if: failure()
+        if: failure() && env.SLACK_WEBHOOK_URL != ''
         uses: 8398a7/action-slack@a74b761b4089b5d730d813fbedcd2ec5d394f3af
         with:
           text: actions/gh-actions-cache E2E test failure

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -28,6 +28,10 @@ jobs:
         key: ${{ matrix.os }}-runner-${{ github.run_number }}-${{ github.run_attempt }}
   canary:
     needs: upload
+    permissions:
+      contents: read
+      packages: read
+      actions: write
     strategy:
       fail-fast: false
       matrix:
@@ -51,18 +55,18 @@ jobs:
         run: go build
       - name: Install extension
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: gh extensions install .
       - name: Print help
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           gh actions-cache --help
       - name: List Command
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cache_found=$(gh actions-cache list --key $CacheKey --limit 100 --branch $GITHUB_REF --order desc --sort created-at | grep  $CacheKey)
           echo $cache_found
@@ -70,7 +74,7 @@ jobs:
       - name: Delete Command
         shell: bash
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_WRITE_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           cache_delete=$(gh actions-cache delete $CacheKey --branch $GITHUB_REF --confirm | grep "Deleted 1 cache entry with key")
           echo $cache_delete


### PR DESCRIPTION
### What are you trying to accomplish?

Doing work in/from forks should not result in ❌.

### What approach did you choose and why?

#24 introduced e2e tests that require all repositories with actions enabled that either update their `main` branch or receive PRs to their `main` branch to have a valid and current `secrets.REPO_WRITE_TOKEN` -- this is frustrating for people who do work in or from forks. PRs from forks do not get access to secrets, and thus they will fail miserably, as in https://github.com/actions/gh-actions-cache/actions/runs/5301791880/jobs/9600582421

I considered adding a fallback, but afaict there's nothing remotely special about what this code is doing, so I merely defined correct permissions which enables this workflow to work out of the box in forks ~or for PRs to this repo from forks~.

I've also made the slack hook conditional on the presence of the slack secret, as I'm not planning to add that secret to my fork(s).


### Anything you want to highlight for special attention from reviewers?

<!-- This is your chance to identify remaining risks and confess any uncertainties you may have about the correctness of the changes. Highlight anything on which you would like a second (or third) opinion. -->

The current changes only able PRs to work in forks, they don't allow PRs to work across forks, to do that would require switching from `pull_request` to `pull_request_target` which is perhaps scarier.