### PR TITLE
Add deprecation message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 > [!IMPORTANT]
 > This functionality has been integrated directly into the `gh` CLI
+>
 > https://cli.github.com/manual/gh_cache
+>
 > This extension should be removed and replaced with usage of `gh cache` directly
+>
 > `gh extension remove actions-cache`
 
 # gh-actions-cache

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!IMPORTANT]
+> This functionality has been integrated directly into the `gh` CLI
+> https://cli.github.com/manual/gh_cache
+> This extension should be removed and replaced with usage of `gh cache` directly
+> `gh extension remove actions-cache`
+
 # gh-actions-cache
 
 ✨ A GitHub (`gh`) [CLI](https://cli.github.com/) extension to manage the GitHub Actions [caches](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows) being used in a GitHub repository. 


### PR DESCRIPTION
This extension is being deprecated in favor of the built-in `gh cache` functionality of the `gh` CLI.

https://cli.github.com/manual/gh_cache